### PR TITLE
Return a default logo if processing fails

### DIFF
--- a/src/server/controllers/logo.js
+++ b/src/server/controllers/logo.js
@@ -25,6 +25,8 @@ const staticFolder = path.resolve(__dirname, '..', '..', 'static');
 
 const debugLogo = debug('logo');
 
+const defaultLogoFile = '/images/default-collective-logo.png';
+
 const getCollectiveImageUrl = async (collectiveSlug, { height, hash } = {}) => {
   const collective = await fetchCollectiveWithCache(collectiveSlug, { hash });
 
@@ -123,6 +125,10 @@ const getLogo = async (imageUrl, height = defaultHeight, width, format, style) =
   return styledImage;
 };
 
+const getDefaultLogo = async (height, width, style) => {
+  return await getLogo(defaultLogoFile, height, width, 'png', style);
+};
+
 export default async function logo(req, res) {
   const collectiveSlug = req.params.collectiveSlug;
   const githubUsername = req.params.githubUsername;
@@ -207,7 +213,9 @@ export default async function logo(req, res) {
         res.send(image);
       } catch (err) {
         logger.error(`logo: error processing ${imageUrl} (${err.message})`);
-        return res.status(500).send('Internal Server Error');
+        const defaultImage = await getDefaultLogo(height, width, style);
+        res.setHeader('content-type', mime.lookup(format));
+        return res.send(defaultImage);
       }
 
       break;

--- a/test/server/badge.routes.test.js
+++ b/test/server/badge.routes.test.js
@@ -140,5 +140,24 @@ describe('badge.routes.test.js', () => {
       },
       timeout,
     );
+    test(
+      'loads the logo as png',
+      async () => {
+        const res = await fetchResponse('/railsgirlsatl/logo.png');
+        expect(res.status).toEqual(200);
+        expect(res.headers.get('content-type')).toEqual('image/png');
+        expect(res.headers.get('cache-control')).toMatch(/public, max-age=[1-9][0-9]{3,7}/);
+      },
+      timeout,
+    );
+    // This test will work until lajacqueline loads a new logo
+    test(
+      'returns a 500 if processing fails',
+      async () => {
+        const res = await fetchResponse('/lajacqueline/logo.jpg');
+        expect(res.status).toEqual(500);
+      },
+      timeout,
+    );
   });
 });

--- a/test/server/badge.routes.test.js
+++ b/test/server/badge.routes.test.js
@@ -150,12 +150,14 @@ describe('badge.routes.test.js', () => {
       },
       timeout,
     );
-    // This test will work until lajacqueline loads a new logo
+    // This test will work until lajacqueline loads a new valid logo
     test(
-      'returns a 500 if processing fails',
+      'return a default logo if processing fails',
       async () => {
         const res = await fetchResponse('/lajacqueline/logo.jpg');
-        expect(res.status).toEqual(500);
+        expect(res.status).toEqual(200);
+        expect(res.headers.get('content-type')).toEqual('image/jpeg');
+        expect(res.headers.get('cache-control')).toMatch(/public, max-age=[1-9][0-9]{3,7}/);
       },
       timeout,
     );


### PR DESCRIPTION
When the file is too large the process runs out of memory as a result returns an error 500. This pull-request solves it by sending a default file in case of error.
To do this I refactored part of the ```logo.js``` file and added the corresponding tests.

Perhaps it would be a good idea to identify files that fail, send them to a resized service, upload them and update the database with this new file. Eventually all files that cause problems will be corrected.