### PR TITLE
fix: prevent resizing images twice when converting to SVG for orgs

### DIFF
--- a/src/server/controllers/avatar.js
+++ b/src/server/controllers/avatar.js
@@ -24,11 +24,11 @@ const sendSvg = (res, svg) => {
   return res.send(svg);
 };
 
-const imageAsSvg = (buffer, { maxHeight, selector, imageformat }) => {
-  const imageHeight = Math.round(maxHeight / 2);
+const imageAsSvg = (buffer, { maxHeight, imageHeight, imageWidth, selector, imageformat }) => {
   const contentType = mime.lookup(imageformat);
 
-  let imageWidth = 64;
+  imageHeight = imageHeight ?? Math.round(maxHeight / 2);
+  imageWidth = imageWidth ?? 64;
 
   if (selector.match(/sponsor/)) {
     try {
@@ -190,7 +190,9 @@ export default async function avatar(req, res) {
       if (image.byteLength === 0) {
         return res.status(400).send('Invalid Image');
       }
-      return sendSvg(res, imageAsSvg(image, { selector, maxHeight, imageFormat }));
+      const imageHeight = Math.round(maxHeight / 2);
+      const imageWidth = Math.round(maxWidth / 2);
+      return sendSvg(res, imageAsSvg(image, { selector, imageHeight, imageWidth, imageFormat }));
     } else {
       return proxyImage(req, res, imageUrl, { imageFormat });
     }


### PR DESCRIPTION
## Background

The sponsorship logos are showing up as 16px by 16px when using the newer `/organization/[...].svg` image URL used in `opencollective-setup` (example: https://github.com/selfdefined/web-app#organizations).

This is likely causing some hesitation from organizations to sponsor some repositories if they see their logo will be super small. This pull request fixes the bug and uses the intended behavior that matches `/sponsor` images.

## Explaination

The reason this is occurring is that we set the max width and height when getting the raster image (source code and example shown below)

https://github.com/opencollective/opencollective-images/blob/afe71c54673733a7aa0b2f8934259dc62613b4d4/src/server/controllers/avatar.js#L177

https://images.opencollective.com/opencollective/logo/square/128/384.png

Then we limit the size of the SVG (source code and example shown below)

https://github.com/opencollective/opencollective-images/blob/afe71c54673733a7aa0b2f8934259dc62613b4d4/src/server/controllers/avatar.js#L28-L31

https://opencollective.com/opencollective/organization/0/avatar.svg

## Issue Links

Fixes https://github.com/opencollective/opencollective/issues/2668