### PR TITLE
Remove trying to run snapshot API testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
     "type": "git",
     "url": "https://github.com/opencollective/opencollective-images.git"
   },
+  "jest": {
+    "testPathIgnorePatterns": ["opencollective-api/"]
+  },
   "private": true,
   "engines": {
     "node": "^12.6.0",

--- a/scripts/run_test.sh
+++ b/scripts/run_test.sh
@@ -41,7 +41,6 @@ wait_for_service IMAGES 127.0.0.1 3001
 
 echo ""
 echo "> Starting server jest tests"
-rm opencollective-api/test/server/graphql/v1/transaction.test.js.snap
 TZ=UTC npx jest test/server/*
 RETURN_CODE=$?
 if [ $RETURN_CODE -ne 0 ]; then


### PR DESCRIPTION
It seems to me that we are trying to run api snapshot tests on this repo and fails. I think running snapshot tests related to the API layer on this repo is unnecessary. If there's a snapshot failure it will be reported on the API side anyways. 😄 