### PR TITLE
Add banner opencollective.com/$slug/financial-contributors.svg

### DIFF
--- a/src/server/lib/graphql.js
+++ b/src/server/lib/graphql.js
@@ -202,7 +202,9 @@ export async function fetchMembers({ collectiveSlug, tierSlug, backerType, isAct
       });
     };
   } else if (backerType) {
-    if (backerType.match(/sponsor/i) || backerType.match(/organization/i)) {
+    if (backerType.match(/financial-contributor/i)) {
+      type = null;
+    } else if (backerType.match(/sponsor/i) || backerType.match(/organization/i)) {
       type = 'ORGANIZATION,COLLECTIVE';
     } else {
       type = 'USER';


### PR DESCRIPTION
Following this route entry:
https://github.com/opencollective/opencollective-images/blob/f2ca296569ef32ed6d64a50c878fe7f8c1b8a046/src/server/routes.js#L72
the controller method will render users by fetching them from the api:
https://github.com/opencollective/opencollective-images/blob/f2ca296569ef32ed6d64a50c878fe7f8c1b8a046/src/server/controllers/banner.js#L39
In the `fetchMembers` method the `backerType` param will be handled if its value is `contributors`:
https://github.com/opencollective/opencollective-images/blob/f2ca296569ef32ed6d64a50c878fe7f8c1b8a046/src/server/lib/graphql.js#L185
or if its value is `sponsor[s]`, `organization[s]` or `individual[s]` and `backer[s]` (which the `else` branch does not check for these two values, so I guess there is some other routing/proxy going on before `opencollective-images` processes the url?)
https://github.com/opencollective/opencollective-images/blob/f2ca296569ef32ed6d64a50c878fe7f8c1b8a046/src/server/lib/graphql.js#L204-L209

Now that allows us to build following urls:

These 4 generate the same svg:
 * https://opencollective.com/playframework/individuals.svg
 * https://opencollective.com/playframework/individual.svg
 * https://opencollective.com/playframework/backers.svg
 * https://opencollective.com/playframework/backer.svg

These 4 generate the same svg:
 * https://opencollective.com/playframework/organizations.svg
 * https://opencollective.com/playframework/organization.svg
* https://opencollective.com/playframework/sponsors.svg
* https://opencollective.com/playframework/sponsor.svg

Finally a svg for contributors:
* https://opencollective.com/playframework/contributors.svg (there is no version without the trailing `s`, because `matching` wasn't used)

**Now with this pull request we would also have:**
* https://opencollective.com/playframework/financial-contributors.svg
* https://opencollective.com/playframework/financial-contributor.svg
which would display *all* financial contributors, bascially a sum of the above individuals + organizations.

This is bascially the same concept you use in the badge when you render 
`https://opencollective.com/playframework/all/badge.svg`
which renders:
<img src="https://opencollective.com/playframework/all/badge.svg" />
Looking at the `badge.js` source:
https://github.com/opencollective/opencollective-images/blob/f2ca296569ef32ed6d64a50c878fe7f8c1b8a046/src/server/controllers/badge.js#L21-L30
where you label `all` backers as `financial contributors` by default.
And even more important that's what you do in the graphql query as well, you just fetch "all" "backers" and define them as "financial contributors" in the last `else` here:
https://github.com/opencollective/opencollective-images/blob/f2ca296569ef32ed6d64a50c878fe7f8c1b8a046/src/server/lib/graphql.js#L110-L119
So that's what I do in the pull request as well to render `financial-contributor.svg`:
I just pass `null` as `type`, to fetch all organizations, users, etc. and the `role = 'BACKER';` line makes sure they are all backers.

What do you think?
I think it makes sense :wink: 