### PR TITLE
Include collectives in organization(s) and sponsor(s) member stats

### DIFF
--- a/src/server/lib/graphql.js
+++ b/src/server/lib/graphql.js
@@ -100,6 +100,7 @@ export async function fetchMembersStats(variables) {
               all
               users
               organizations
+              collectives
             }
           }
         }
@@ -108,7 +109,7 @@ export async function fetchMembersStats(variables) {
     processResult = (res) => {
       let name, count;
       if (backerType.match(/sponsor/i) || backerType.match(/organization/i)) {
-        count = res.Collective.stats.backers.organizations;
+        count = res.Collective.stats.backers.organizations + res.Collective.stats.backers.collectives;
         name = backerType;
       } else if (backerType.match(/backer/i) || backerType.match(/individual/i)) {
         count = res.Collective.stats.backers.users;


### PR DESCRIPTION
While working on #502 I found out that when fetching organisations/sponsors for the banner the type that will be fetched from the api gets set to `ORGANIZATION` **and** `COLLECTIVE`:
https://github.com/opencollective/opencollective-images/blob/f2ca296569ef32ed6d64a50c878fe7f8c1b8a046/src/server/lib/graphql.js#L205-L209

When fetching the member stats (for the badge) you only count organizations however, but not collectives:
https://github.com/opencollective/opencollective-images/blob/f2ca296569ef32ed6d64a50c878fe7f8c1b8a046/src/server/lib/graphql.js#L110-L111

Isn't that inconsistent?
Either you should never take into account collectives or add them to the stats as well (what my pull request does).
If you think the former is better, feel free to close this pull request, I can add another one removing `COLLECTIVE` from the first code snippet.