### PR TITLE
feat: add doFollow parameter for contributor links

### DIFF
--- a/src/server/controllers/banner.js
+++ b/src/server/controllers/banner.js
@@ -18,6 +18,7 @@ export default async function banner(req, res) {
   const height = Number(req.query.height) || 0;
   const { avatarHeight, margin } = req.query;
   const showBtn = parseToBooleanDefaultTrue(req.query.button);
+  const doFollow = parseToBooleanDefaultFalse(req.query.doFollow);
 
   // handle includeAnonymous, default to true for tiers
   let includeAnonymous;
@@ -70,6 +71,7 @@ export default async function banner(req, res) {
     margin,
     collectiveSlug,
     includeAnonymous,
+    doFollow,
   })
     .then((content) => {
       res.setHeader('Content-Type', 'image/svg+xml;charset=utf-8');

--- a/src/server/lib/svg-banner.js
+++ b/src/server/lib/svg-banner.js
@@ -32,7 +32,7 @@ export function generateSvgBanner(usersList, options) {
   // usersList might come from LRU-cache and we don't want to modify it
   const users = cloneDeep(usersList);
 
-  const { limit, collectiveSlug } = options;
+  const { limit, collectiveSlug, doFollow = false } = options;
 
   const imageWidth = options.width;
   const imageHeight = options.height;
@@ -124,7 +124,9 @@ export function generateSvgBanner(usersList, options) {
         const imageLink = `<a xlink:href="${website.replace(
           /&/g,
           '&amp;',
-        )}" class="opencollective-svg" target="_blank" rel="nofollow sponsored" id="${user.slug}">${image}</a>`;
+        )}" class="opencollective-svg" target="_blank" rel=${doFollow ? 'sponsored' : 'nofollow sponsored'} id="${
+          user.slug
+        }">${image}</a>`;
         images.push(imageLink);
         posX += avatarWidth + margin;
       }


### PR DESCRIPTION
This PR adds a new `doFollow` parameter that allows collectives to opt-in to
"dofollow" links in their contributor widgets. When enabled, the "nofollow"
attribute is removed from contributor links while maintaining the "sponsored"
attribute for proper link attribution.

Changes:
- Added doFollow parameter parsing in banner.js
- Modified link generation in svg-banner.js

The default behavior (nofollow links) remains unchanged unless explicitly
opted into using the doFollow parameter.

Fixes https://github.com/opencollective/opencollective/issues/5968