### PR TITLE
Add follow parameter for tier banner links

### DIFF
--- a/src/server/controllers/banner.js
+++ b/src/server/controllers/banner.js
@@ -17,6 +17,7 @@ export default async function banner(req, res) {
   const width = Number(req.query.width) || 0;
   const height = Number(req.query.height) || 0;
   const { avatarHeight, margin } = req.query;
+  const follow = parseToBooleanDefaultFalse(req.query.follow);
   const showBtn = parseToBooleanDefaultTrue(req.query.button);
 
   // handle includeAnonymous, default to true for tiers
@@ -68,6 +69,7 @@ export default async function banner(req, res) {
     height,
     avatarHeight,
     margin,
+    follow,
     collectiveSlug,
     includeAnonymous,
   })

--- a/src/server/lib/svg-banner.js
+++ b/src/server/lib/svg-banner.js
@@ -32,7 +32,7 @@ export function generateSvgBanner(usersList, options) {
   // usersList might come from LRU-cache and we don't want to modify it
   const users = cloneDeep(usersList);
 
-  const { limit, collectiveSlug } = options;
+  const { limit, collectiveSlug, follow } = options;
 
   const imageWidth = options.width;
   const imageHeight = options.height;
@@ -121,10 +121,11 @@ export function generateSvgBanner(usersList, options) {
           posX = margin;
         }
         const image = `<image x="${posX}" y="${posY}" width="${avatarWidth}" height="${avatarHeight}" xlink:href="data:${contentType};base64,${base64data}"/>`;
+        const relAttribute = follow ? '' : ' rel="nofollow sponsored"';
         const imageLink = `<a xlink:href="${website.replace(
           /&/g,
           '&amp;',
-        )}" class="opencollective-svg" target="_blank" rel="nofollow sponsored" id="${user.slug}">${image}</a>`;
+        )}" class="opencollective-svg" target="_blank"${relAttribute} id="${user.slug}">${image}</a>`;
         images.push(imageLink);
         posX += avatarWidth + margin;
       }

--- a/test/server/badge.routes.test.js
+++ b/test/server/badge.routes.test.js
@@ -91,6 +91,25 @@ describe('badge.routes.test.js', () => {
       timeout,
     );
 
+    test(
+      'keeps tier banner links nofollow by default',
+      async () => {
+        const resText = await fetchText('/ancientbeast/tiers/sponsor.svg?limit=1');
+        expect(resText).toMatch(/rel="nofollow sponsored"/);
+      },
+      timeout,
+    );
+
+    test(
+      'removes rel from tier banner links when follow=true',
+      async () => {
+        const resText = await fetchText('/ancientbeast/tiers/sponsor.svg?limit=1&follow=true');
+        expect(resText).toMatch(/target="_blank"/);
+        expect(resText).not.toMatch(/rel="nofollow sponsored"/);
+      },
+      timeout,
+    );
+
     test.skip(
       'loads the banner (png)',
       async () => {


### PR DESCRIPTION
## Summary
- add a follow query parameter to tier banner routes
- keep rel="nofollow sponsored" by default
- remove the rel attribute entirely when follow=true so the banner emits dofollow links
- cover the default and opt-in cases with route tests

## Testing
- IMAGES_URL=http://localhost:4010 npx eslint src/server/controllers/banner.js src/server/lib/svg-banner.js test/server/badge.routes.test.js
- IMAGES_URL=http://localhost:4010 npx jest --runInBand test/server/badge.routes.test.js -t "tier banner links"
- IMAGES_URL=http://localhost:4010 npx jest --runInBand test/server/badge.routes.test.js -t "loads the banner \\(svg\\)"
- manual curl check against a local server for both default and follow=true outputs

Refs opencollective/opencollective#5968