### PR TITLE
Validate proxy image source URLs

### DIFF
--- a/src/server/lib/utils.js
+++ b/src/server/lib/utils.js
@@ -96,10 +96,14 @@ export const getUiAvatarUrl = (name, size, rounded = true, background = 'E6F3FF'
   return url.toString();
 };
 
-export const isValidUrl = (string) => {
+export const isValidHttpUrl = (string) => {
+  if (typeof string !== 'string') {
+    return false;
+  }
+
   try {
-    new URL(string);
-    return true;
+    const url = new URL(string);
+    return ['http:', 'https:'].includes(url.protocol);
   } catch (err) {
     return false;
   }

--- a/src/server/routes.js
+++ b/src/server/routes.js
@@ -1,6 +1,6 @@
 import request from 'request';
 
-import { getCloudinaryUrl, isValidUrl } from './lib/utils';
+import { getCloudinaryUrl, isValidHttpUrl } from './lib/utils';
 import controllers from './controllers';
 import { logger } from './logger';
 import { maxAge } from './middlewares';
@@ -21,7 +21,7 @@ export const loadRoutes = (app) => {
   app.get('/proxy/images', maxAge(7200), (req, res) => {
     const { src, width, height, query } = req.query;
 
-    if (!isValidUrl(src)) {
+    if (!isValidHttpUrl(src)) {
       return res.status(400).send('Invalid parameter: "src"');
     }
 

--- a/test/server/utils.test.js
+++ b/test/server/utils.test.js
@@ -1,0 +1,19 @@
+import { isValidHttpUrl } from '../../src/server/lib/utils';
+
+describe('utils.test.js', () => {
+  describe('isValidHttpUrl', () => {
+    test.each(['https://opencollective.com/logo.png', 'http://example.com/image.jpg'])(
+      'accepts HTTP image URLs: %s',
+      (url) => {
+        expect(isValidHttpUrl(url)).toEqual(true);
+      },
+    );
+
+    test.each(['javascript:alert(1)', 'file:///etc/passwd', 'data:image/svg+xml,<svg></svg>', ['https://example.com']])(
+      'rejects unsupported proxy image URLs: %s',
+      (url) => {
+        expect(isValidHttpUrl(url)).toEqual(false);
+      },
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Restrict proxy image source validation to string HTTP(S) URLs before building the Cloudinary fetch URL.
- Rename the helper to `isValidHttpUrl` so the protocol requirement is explicit.
- Add unit coverage for accepted HTTP(S) URLs and rejected unsupported schemes/non-string values.

## Tests
- `npx jest test/server/utils.test.js`
- `npx eslint src/server/routes.js src/server/lib/utils.js test/server/utils.test.js`
- `npx prettier --check src/server/routes.js src/server/lib/utils.js test/server/utils.test.js`
